### PR TITLE
Linux uptime Sensu check

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Functionality
 
 ## Files
- * bin/check-uptime.rb.rb
+ * bin/check-uptime.rb
  * bin/metrics-uptime.rb
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 ## Functionality
 
 ## Files
+ * bin/check-uptime.rb.rb
  * bin/metrics-uptime.rb
 
 ## Usage
@@ -18,3 +19,4 @@
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)
 
 ## Notes
+

--- a/bin/check-uptime.rb
+++ b/bin/check-uptime.rb
@@ -1,0 +1,54 @@
+#! /usr/bin/env ruby
+#  encoding: UTF-8
+#
+#   check-uptime
+#
+# DESCRIPTION:
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#   check-uptime.rb --help
+#
+# NOTES:
+#   Checks the uptime of the system and warns the user if the system
+#   has been crashed or rebooted.
+#
+# LICENSE:
+#   Copyright 2012 Kees Remmelzwaal <kees@fastmail.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+require 'sensu-plugin/check/cli'
+
+class CheckUptime < Sensu::Plugin::Check::CLI
+
+  option :warn,
+         short: '-w WARN',
+         proc: proc(&:to_i),
+         default: 180 
+
+  def run
+
+    uptime_sec  = IO.read('/proc/uptime').split[0].to_i
+    uptime_date = Time.now - uptime_sec
+
+    if uptime_sec < config[:warn]
+      message "System boot detected (#{uptime_sec} seconds up)"
+      warning
+    end
+
+    message "System booted at #{uptime_date}"
+    ok
+  end
+end
+
+
+

--- a/bin/check-uptime.rb
+++ b/bin/check-uptime.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env ruby
+#!/opt/sensu/embedded/bin/ruby
 #  encoding: UTF-8
 #
 #   check-uptime
@@ -18,20 +18,21 @@
 #   check-uptime.rb --help
 #
 # NOTES:
-#   Checks the uptime of the system and warns the user if the system
-#   has been crashed or rebooted.
+#   Checks the systems uptime and warns if the system has been rebooted. 
 #
 # LICENSE:
 #   Copyright 2012 Kees Remmelzwaal <kees@fastmail.com>
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
 #
+
 require 'sensu-plugin/check/cli'
 
 class CheckUptime < Sensu::Plugin::Check::CLI
 
   option :warn,
-         short: '-w WARN',
+         short: '-w SEC ',
+         description: 'Warn if uptime is below SEC',
          proc: proc(&:to_i),
          default: 180 
 

--- a/bin/check-uptime.rb
+++ b/bin/check-uptime.rb
@@ -1,4 +1,4 @@
-#!/opt/sensu/embedded/bin/ruby
+#! /usr/bin/env ruby
 #  encoding: UTF-8
 #
 #   check-uptime

--- a/bin/check-uptime.rb
+++ b/bin/check-uptime.rb
@@ -18,7 +18,7 @@
 #   check-uptime.rb --help
 #
 # NOTES:
-#   Checks the systems uptime and warns if the system has been rebooted. 
+#   Checks the systems uptime and warns if the system has been rebooted.
 #
 # LICENSE:
 #   Copyright 2012 Kees Remmelzwaal <kees@fastmail.com>
@@ -29,15 +29,13 @@
 require 'sensu-plugin/check/cli'
 
 class CheckUptime < Sensu::Plugin::Check::CLI
-
   option :warn,
          short: '-w SEC ',
          description: 'Warn if uptime is below SEC',
          proc: proc(&:to_i),
-         default: 180 
+         default: 180
 
   def run
-
     uptime_sec  = IO.read('/proc/uptime').split[0].to_i
     uptime_date = Time.now - uptime_sec
 
@@ -50,6 +48,3 @@ class CheckUptime < Sensu::Plugin::Check::CLI
     ok
   end
 end
-
-
-


### PR DESCRIPTION
We use this check at our company because we have experienced that a reboot of a system is sometimes unnoticed. Especially with the Redhat7 machines which uses systemd and boots very fast.