### PR TITLE
Compatibility osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 2.0
 - 2.1
 - 2.2
 - 2.3.0
@@ -27,7 +26,6 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 2.0
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This Changelog following the conventions laid out [here](https://github.com/sens
 
 ## [Unreleased]
 
+### Added
+- check-uptime.rbheck-uptime.rb: added osx support (@jjdiazgarcia)
+
 ## [1.2.0] - 2017-09-17
 ### Changed
 - updated PR template and CHANGELOG to point to new CHANGELOG guidelines (@majormoses)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This Changelog following the conventions laid out [here](https://github.com/sens
 
 ## [Unreleased]
 
+### Breaking Changes
+- removed ruby 2.0 support && testing (@majormoses)
+
 ### Added
 - check-uptime.rbheck-uptime.rb: added osx support (@jjdiazgarcia)
 

--- a/bin/check-uptime.rb
+++ b/bin/check-uptime.rb
@@ -49,8 +49,10 @@ class CheckUptime < Sensu::Plugin::Check::CLI
     if os.chomp == 'Darwin'
       uptime_timestamp = `sysctl kern.boottime | cut -d= -f2 | cut -d" " -f2 | cut -d, -f1`.to_i
       uptime_sec = `date +%s`.to_i - uptime_timestamp
-    else
+    elsif os.chomp == 'Linux'
       uptime_sec = IO.read('/proc/uptime').split[0].to_i
+    else
+      message "platform: #{os} is not supported, please open an issue with the output of '`uname`'."
     end
     uptime_date = Time.now - uptime_sec
 

--- a/bin/check-uptime.rb
+++ b/bin/check-uptime.rb
@@ -20,6 +20,7 @@
 # NOTES:
 #   Checks the systems uptime and warns if the system has been rebooted.
 #   2017 Juan Moreno Martinez - Add reverse option
+#   2017 Jeronimo Jose Diaz Garcia - Compatibility OS X
 #
 # LICENSE:
 #   Copyright 2012 Kees Remmelzwaal <kees@fastmail.com>
@@ -44,7 +45,13 @@ class CheckUptime < Sensu::Plugin::Check::CLI
          default: false
 
   def run
-    uptime_sec  = IO.read('/proc/uptime').split[0].to_i
+    os = `uname`
+    if os.chomp == "Darwin"
+      uptime_timestamp =  %x(sysctl kern.boottime | cut -d= -f2 | cut -d" " -f2 | cut -d, -f1).to_i
+      uptime_sec = %x(date +%s).to_i - uptime_timestamp
+    else
+      uptime_sec  = IO.read('/proc/uptime').split[0].to_i
+    end
     uptime_date = Time.now - uptime_sec
 
     if config[:greater] && uptime_sec > config[:warn]

--- a/bin/check-uptime.rb
+++ b/bin/check-uptime.rb
@@ -46,11 +46,11 @@ class CheckUptime < Sensu::Plugin::Check::CLI
 
   def run
     os = `uname`
-    if os.chomp == "Darwin"
-      uptime_timestamp =  %x(sysctl kern.boottime | cut -d= -f2 | cut -d" " -f2 | cut -d, -f1).to_i
-      uptime_sec = %x(date +%s).to_i - uptime_timestamp
+    if os.chomp == 'Darwin'
+      uptime_timestamp = `sysctl kern.boottime | cut -d= -f2 | cut -d" " -f2 | cut -d, -f1`.to_i
+      uptime_sec = `date +%s`.to_i - uptime_timestamp
     else
-      uptime_sec  = IO.read('/proc/uptime').split[0].to_i
+      uptime_sec = IO.read('/proc/uptime').split[0].to_i
     end
     uptime_date = Time.now - uptime_sec
 

--- a/sensu-plugins-uptime-checks.gemspec
+++ b/sensu-plugins-uptime-checks.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.1.0'
 
   s.summary                = 'Sensu plugins for uptime-checks'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Resolve Issue #11 

Before:

> /opt/sensu/embedded/bin/check-uptime.rb
Check failed to run: No such file or directory @ rb_sysopen - /proc/uptime, ["/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugins-uptime-checks-1.1.0/bin/check-uptime.rb:44:in `read'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugins-uptime-checks-1.1.0/bin/check-uptime.rb:44:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.4.0/gems/sensu-plugin-1.4.5/lib/sensu-plugin/cli.rb:58:in `block in <class:CLI>'"]

After:

> /opt/sensu/embedded/bin/check-uptime.rb
CheckUptime OK: System booted at 2017-10-09 10:14:56 +0200